### PR TITLE
Extract interface payload from bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea

--- a/ifcreate.py
+++ b/ifcreate.py
@@ -1,0 +1,31 @@
+#!/usr/local/bin/python3
+
+import pyangbind.lib.pybindJSON as pybindJSON
+import pyangbind.lib.xpathhelper as xpathhelper
+
+import ocbind
+
+def ifcreate(ifname):
+    ph = xpathhelper.YANGPathHelper()
+
+    src_ocif = ocbind.openconfig_interfaces(path_helper=ph)
+
+    src_ocif.interfaces.interface.add(ifname)
+    newif = src_ocif.interfaces.interface[ifname]
+
+    newif.config.description = "Linux " + ifname + " interface"
+    newif.config.enabled = True
+    newif.ethernet.config.duplex_mode = "FULL"
+    newif.ethernet.config.auto_negotiate = True
+
+    newif.subinterfaces.subinterface.add(0)
+    subint0 = newif.subinterfaces.subinterface[0]
+    subint0.config.description = "Primary public IP address"
+    subint0.ipv4.addresses.address.add("192.0.2.1")
+
+    nsub = subint0.ipv4.addresses.address["192.0.2.1"]
+    nsub.config.prefix_length = 24
+
+    # Serialise the entire object
+    # print(pybindJSON.dumps(src_ocif))
+    return pybindJSON.dumps(src_ocif)

--- a/py_gnmicli.py
+++ b/py_gnmicli.py
@@ -7,6 +7,8 @@ import os
 import re
 import sys
 
+from ifcreate import ifcreate
+
 import six
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "gnmi"))
@@ -51,7 +53,7 @@ def _create_parser():
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('-e', '--endpoint', type=str, help='gNMI address:port endpoint', required=True)
     parser.add_argument('-t', '--target', type=str, help='gNMI target', required=True)
-    parser.add_argument('-m', '--mode', choices=['get', 'set', 'delete'], help='get, set or delete', default='get')
+    parser.add_argument('-m', '--mode', choices=['get', 'set', 'delete', 'ifadd'], help='get, set or delete or ifadd', default='get')
     parser.add_argument('-val', '--value', type=str, help='value', required=False)
     parser.add_argument('-pkey', '--private_key', type=str, help='Private key file path', required=True)
     parser.add_argument('-rcert', '--root_cert', type=str, help='Root CA file path', required=True)
@@ -139,6 +141,11 @@ def main():
         print(response)
     elif mode == 'delete':
         response = stub.Set(gnmi_pb2.SetRequest(delete=[paths]))
+        print(response)
+    elif mode == 'ifadd':
+        ifjson = ifcreate("eth2")
+        print("Sending\n", ifjson)
+        response = stub.Set(gnmi_pb2.SetRequest(update=[gnmi_pb2.Update(path=paths, val=_get_val(ifjson), )]))
         print(response)
 
 if __name__ == '__main__':


### PR DESCRIPTION
I added a new use case that extracts the JSON from the object model and sends it to onos-config

This crashes onos-config for the moment as it can't handle JSON payloads See issue #597 on onos-config